### PR TITLE
Fix Response return types

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -14,7 +14,7 @@ class Response
     protected $body;
 
     /**
-     * @param string $statusCode statusCode
+     * @param int    $statusCode statusCode
      * @param string $body       body
      */
     public function __construct($statusCode, $body)
@@ -24,7 +24,7 @@ class Response
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getStatusCode()
     {
@@ -32,7 +32,7 @@ class Response
     }
 
     /**
-     * @return string
+     * @return mixed
      */
     public function getBody()
     {


### PR DESCRIPTION
As my IDE's linter was causing me headaches with very valid complaints about these issues, I'd like to propose the following changes:
- Change the DocBlock for `Response::getStatusCode()` to reflect the fact that `Guzzle\Response::getStatusCode()` returns a integer.
- Change the DocBlock for `Response::getBody()` to reflect the fact that `json_decode` can return anything.

These are only minor changes, but critique is welcome.