### PR TITLE
Request/reports by advertiser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php" : "~5.6|~7.0",
     "guzzlehttp/guzzle": "~6.0",
-    "symfony/options-resolver": "~2.6|~3.0"
+    "symfony/options-resolver": "~2.6|~3.0|^4.0"
   },
   "require-dev": {
     "atoum/atoum": "dev-master",

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -32,7 +32,7 @@ class Response
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getBody()
     {

--- a/src/Request/GetReportsAdvertiserDefinition.php
+++ b/src/Request/GetReportsAdvertiserDefinition.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Yuzu\Awin\Request;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * GetReportsAdvertiserDefinition
+ *
+ * @author Julien Devergnies <j.devergnies@outlook.com>
+ */
+class GetReportsAdvertiserDefinition extends AbstractRequestDefinition
+{
+    public function getMethod()
+    {
+        return 'GET';
+    }
+
+    public function getBaseUrl()
+        return sprintf('/publishers/%s/reports/advertiser', $this->getOptions()['publisherId']);
+    }
+
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefined([
+            'publisherId',
+            'startDate',
+            'endDate',
+            'dateType',
+            'timezone',
+            'region'
+        ]);
+        $resolver->setAllowedValues('dateType', ['transaction', 'validation']);
+        $resolver->setAllowedValues('timezone', ['Europe/Berlin', 'Europe/Paris', 'Europe/London', 'Europe/Dublin', 'Canada/Eastern', 'Canada/Central', 'Canada/Mountain', 'Canada/Pacific', 'US/Eastern', 'US/Central', 'US/Mountain', 'US/Pacific', 'UTC']);
+        $resolver->setAllowedValues('region', ['AT', 'AU', 'BE', 'BR', 'CA', 'CH', 'DE', 'DK', 'ES', 'FI', 'FR', 'GB', 'IE', 'IT', 'NL', 'NO', 'PL', 'SE', 'US']);
+        $resolver->setRequired('publisherId');
+    }
+}

--- a/src/Request/GetReportsAdvertiserDefinition.php
+++ b/src/Request/GetReportsAdvertiserDefinition.php
@@ -17,6 +17,7 @@ class GetReportsAdvertiserDefinition extends AbstractRequestDefinition
     }
 
     public function getBaseUrl()
+    {
         return sprintf('/publishers/%s/reports/advertiser', $this->getOptions()['publisherId']);
     }
 

--- a/tests/Units/Request/GetReportsAdvertiserDefinition.php
+++ b/tests/Units/Request/GetReportsAdvertiserDefinition.php
@@ -82,7 +82,7 @@ class GetReportsAdvertiserDefinition extends atoum\test
                         'publisherId' => 'XXX',
                         'timezone' => 'Europe/Paris',
                         'startDate' => new \DateTime("-2days"),
-                        'endDate' => new \DateTime("yesterday")
+                        'endDate' => new \DateTime("yesterday"),
                         'region' => 'wrongValue'
                     );
                     $this->newTestedInstance($options);

--- a/tests/Units/Request/GetReportsAdvertiserDefinition.php
+++ b/tests/Units/Request/GetReportsAdvertiserDefinition.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Yuzu\Awin\Tests\Units\Request;
+
+use mageekguy\atoum;
+
+class GetReportsAdvertiserDefinition extends atoum\test
+{
+    public function testConstruct()
+    {
+        $this
+            ->given(
+                $options = array(
+                    'publisherId' => 'XXX'
+                )
+            )
+            ->if($this->newTestedInstance($options))
+            ->then
+            ->object($this->testedInstance)->isTestedInstance()
+        ;
+    }
+
+    public function testConstructWithParams()
+    {
+        $this
+            ->given(
+                $options = array(
+                    'publisherId' => 'XXX',
+                    'timezone' => 'Europe/Paris',
+                    'startDate' => new \DateTime("-2days"),
+                    'endDate' => new \DateTime("yesterday")
+                )
+            )
+            ->if($this->newTestedInstance($options))
+                ->then
+                    ->object($this->testedInstance)->isTestedInstance()
+        ;
+    }
+
+    
+
+    public function testConstructWithAllParams()
+    {
+        $this
+            ->given(
+                $options = array(
+                    'publisherId' => 'XXX',
+                    'timezone' => 'Europe/Paris',
+                    'startDate' => new \DateTime("-2days"),
+                    'endDate' => new \DateTime("yesterday"),
+                    'dateType' => 'validation',
+                    'timezone' => 'Europe/Paris',
+                    'region' => 'FR'
+                )
+            )
+            ->if($this->newTestedInstance($options))
+                ->then
+                    ->object($this->testedInstance)->isTestedInstance()
+        ;
+    }
+
+    public function testConstructWithWrongParams()
+    {
+        $this
+            ->exception(
+                function () {
+                    $options = array(
+                        'wrongParam' => 'wrongValue'
+                    );
+                    $this->newTestedInstance($options);
+                }
+            )
+        ;
+    }
+
+    public function testConstructWithWrongParamsValue()
+    {
+        $this
+            ->exception(
+                function () {
+                    $options = array(
+                        'publisherId' => 'XXX',
+                        'timezone' => 'Europe/Paris',
+                        'startDate' => new \DateTime("-2days"),
+                        'endDate' => new \DateTime("yesterday")
+                        'region' => 'wrongValue'
+                    );
+                    $this->newTestedInstance($options);
+                }
+            )
+        ;
+    }
+}


### PR DESCRIPTION
This PR is to make the reports by advertiser available.

It also allows version ^4 of the options resolver.
Tests has been added.
The `getBody()` method of the _Response_ is now hinted as `array `in the comment block. It makes more sense as we return an from `json_decode`.