### PR TITLE
Allow for Guzzle 7 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "require": {
     "php" : "~5.6|~7.0",
-    "guzzlehttp/guzzle": "~6.0",
+    "guzzlehttp/guzzle": "^6.0|^7.0.1",
     "symfony/options-resolver": "~2.6|~3.0|^4.0"
   },
   "require-dev": {


### PR DESCRIPTION
We've recently upgraded to Laravel 8, for which Guzzle 7 is a requirement. the newest version of Guzzle comes with very few breaking changes, and as such Awin PHP continues to function perfectly in our codebase with the latest version.

Thus, my proposal is to simply update the dependency list to allow for Guzzle 7 to be used.